### PR TITLE
Updated vrsettings logic to use new section suffix

### DIFF
--- a/resources/settings/default.vrsettings
+++ b/resources/settings/default.vrsettings
@@ -54,8 +54,8 @@
   {
     "__type": "communication_protocol:1",
     "__title": "Bluetooth Serial",
-	  "left_name": "lucidgloves-left",
-  	"right_name": "lucidgloves-right"
+    "left_name": "lucidgloves-left",
+    "right_name": "lucidgloves-right"
   },
   "opengloves.encoding_legacy":
   {

--- a/resources/settings/default.vrsettings
+++ b/resources/settings/default.vrsettings
@@ -1,5 +1,5 @@
 {
-  "driver_openglove":
+  "opengloves.driver_openglove":
   {
     "__title": "OpenGlove Configuration",
     "left_enabled": true,
@@ -8,21 +8,21 @@
     "device_driver": 1, //title:Device Driver Emulation
     "encoding_protocol": 1 //title:Encoding Protocol
   },
-  "device_lucidgloves":
+  "opengloves.device_lucidgloves":
   {
     "__title": "Lucid Glove",
     "__type": "device_driver:0",
     "left_serial_number": "lucidgloves-left",
     "right_serial_number": "lucidgloves-right"
   },
-  "device_knuckles":
+  "opengloves.device_knuckles":
   {
     "__title": "Knuckles Emulation",
     "__type": "device_driver:1",
     "left_serial_number": "LHR-E217CD00",
     "right_serial_number": "LHR-E217CD01"
   },
-  "pose_settings":
+  "opengloves.pose_settings":
   {
     "__title": "Pose settings",
     "right_x_offset_position": -0.1,
@@ -42,7 +42,7 @@
     "controller_override_left": 3,
     "controller_override_right": 4
   },
-  "communication_serial":
+  "opengloves.communication_serial":
   {
     "__type": "communication_protocol:0",
     "__title": "USB Serial",
@@ -50,20 +50,20 @@
     "right_port": "\\\\.\\COM5",
     "baud_rate": 115200
   },
-  "communication_btserial": 
+  "opengloves.communication_btserial": 
   {
     "__type": "communication_protocol:1",
     "__title": "Bluetooth Serial",
-	"left_name": "lucidgloves-left",
+	  "left_name": "lucidgloves-left",
   	"right_name": "lucidgloves-right"
   },
-  "encoding_legacy":
+  "opengloves.encoding_legacy":
   {
     "__type": "encoding_protocol: 0",
     "__title": "Legacy Encoding",
     "max_analog_value": 1023
   },
-  "encoding_alpha":
+  "opengloves.encoding_alpha":
   {
     "__type": "encoding_protocol: 1",
     "__title": "Alpha Protocol",

--- a/sidecar/main.h
+++ b/sidecar/main.h
@@ -1,1 +1,14 @@
 #pragma once
+
+#include <string>
+
+#include "json.hpp"
+
+const std::string SECTION_NAME_PREFIX = "opengloves.";
+
+int GetSettings(nlohmann::json& json);
+int SetSettings(const nlohmann::json& json);
+int AutoCalibrate(const nlohmann::json& json);
+
+int main();
+

--- a/src/pages/Configuration.svelte
+++ b/src/pages/Configuration.svelte
@@ -1,5 +1,6 @@
 <script>
     import {
+        primaryConfigurationKey,
         createConfiguration,
         getConfiguration,
         saveConfiguration,
@@ -84,16 +85,16 @@
                                     {#if Array.isArray(value.options)}
                                         <Select
                                                 onSelectItemChanged={selectedKey => {
-                                        configurationOptions.driver_openglove.options[key] = selectedKey;
+                                        configurationOptions[primaryConfigurationKey].options[key] = selectedKey;
                                     }}
                                                 options={Object.entries(value.options).map(([k, v]) => ({
                                         title: v.title,
                                         value: parseInt(k),
                                     }))}
-                                                defaultValue={configurationOptions.driver_openglove.options[key]}
+                                                defaultValue={configurationOptions[primaryConfigurationKey].options[key]}
                                         />
                                         <ConfigList
-                                                bind:configItems={value.options[configurationOptions.driver_openglove.options[key]].options}/>
+                                                bind:configItems={value.options[configurationOptions[primaryConfigurationKey].options[key]].options}/>
                                     {:else}
                                         <ConfigList
                                                 hiddenKeys={Object.keys(configurationOptions).map((k) => k)}

--- a/src/pages/Functions.svelte
+++ b/src/pages/Functions.svelte
@@ -25,7 +25,7 @@
         $state.autoCalibrate.timer = $state.autoCalibrate.form.calibrationTimer;
 
         try {
-            const start = await openSidecar('sidecar', 'functions_autocalibrate', {
+            await openSidecar('sidecar', 'functions_autocalibrate', {
                 start: true,
                 right_hand: $state.autoCalibrate.form.forRightHand
             });

--- a/src/utils/configuration.js
+++ b/src/utils/configuration.js
@@ -13,7 +13,7 @@ export const primaryConfigurationKey = 'opengloves.driver_openglove';
  * @param configObj {Object} Object for properties
  * @return {Promise<String>} Return values from properties provided
  */
-const getValuesForConfiguration = async (configObj) => openSidecar("sidecar", "settings_get", configObj);
+const getValuesForConfiguration = async (configObj) => (await openSidecar("sidecar", "settings_get", configObj)).join('\n');
 
 export const getConfiguration = async () => {
     const cached = await ConfigurationStore.getConfiguration();

--- a/src/utils/configuration.js
+++ b/src/utils/configuration.js
@@ -6,6 +6,8 @@ import {deepOverwrite} from "./object";
 import ConfigurationStore from '../stores/configuration';
 import {openSidecar} from "./sidecar";
 
+export const primaryConfigurationKey = 'opengloves.driver_openglove';
+
 /***
  * Returns values for configuration properties provided using external executable
  * @param configObj {Object} Object for properties
@@ -36,11 +38,10 @@ export const createConfiguration = (configurationOptions) => {
 
     const temp = JSON.parse(JSON.stringify(configurationOptions));
 
-    const result = {
-        driver_openglove: temp.driver_openglove.options,
-    };
+    const result = {};
+    result[primaryConfigurationKey] = temp[primaryConfigurationKey].options;
 
-    delete temp.driver_openglove;
+    delete temp[primaryConfigurationKey];
     Object.entries(temp).forEach(([k,v]) => {
         if(Array.isArray(v.options)) {
             v.options.forEach((v2, k2) => {
@@ -92,14 +93,13 @@ export const saveConfiguration = async (configObj) => openSidecar("sidecar", "se
     }
  */
 export const parseConfiguration = (configObj) => {
-    const result = {
-            driver_openglove: {
-                options: {},
-            },
+    const result = {};
+    result[primaryConfigurationKey] = {
+        options: {}
     };
 
-    Object.entries(configObj.driver_openglove).forEach(([k, v]) => {
-        const sectionHasOptions = configObj.driver_openglove[Symbol.for(`after:${k}`)];
+    Object.entries(configObj[primaryConfigurationKey]).forEach(([k, v]) => {
+        const sectionHasOptions = configObj[primaryConfigurationKey][Symbol.for(`after:${k}`)];
         if (sectionHasOptions) {
             result[k] = {
                 title: parseComment(sectionHasOptions[0].value).title,
@@ -108,12 +108,12 @@ export const parseConfiguration = (configObj) => {
         }
 
         if(k === '__title')
-            result.driver_openglove.title = v;
+            result[primaryConfigurationKey].title = v;
         else
-            result.driver_openglove.options[k] = v;
+            result[primaryConfigurationKey].options[k] = v;
 
     });
-    delete configObj.driver_openglove;
+    delete configObj[primaryConfigurationKey];
 
     Object.entries(configObj).forEach(([k, v]) => {
 

--- a/src/utils/configuration.js
+++ b/src/utils/configuration.js
@@ -13,7 +13,7 @@ export const primaryConfigurationKey = 'opengloves.driver_openglove';
  * @param configObj {Object} Object for properties
  * @return {Promise<String>} Return values from properties provided
  */
-const getValuesForConfiguration = async (configObj) => (await openSidecar("sidecar", "settings_get", configObj)).join('\n');
+const getValuesForConfiguration = async (configObj) => (await openSidecar("sidecar", "settings_get", configObj)).pop();
 
 export const getConfiguration = async () => {
     const cached = await ConfigurationStore.getConfiguration();

--- a/src/utils/sidecar.js
+++ b/src/utils/sidecar.js
@@ -4,8 +4,19 @@ export const openSidecar = async (program, type, data) => {
     const sidecar = Command.sidecar(program);
 
     const promiseDataReceived = new Promise((resolve, reject) => {
-        sidecar.stdout.on('data', e => resolve(e));
-        sidecar.stderr.on('data', e => reject(e));
+        // Listen for output
+        const stdout = [];
+        sidecar.stdout.on('data', e => stdout.push(e));
+        const stderr = [];
+        sidecar.stderr.on('data', e => stderr.push(e));
+
+        // Report output on exit
+        sidecar.on('close', () => {
+            if (stderr.length > 0)
+                reject(stderr.join('\n'));
+            else
+                resolve(stdout.join('\n'));
+        });
     });
 
     const child = await sidecar.spawn();

--- a/src/utils/sidecar.js
+++ b/src/utils/sidecar.js
@@ -9,8 +9,9 @@ export const openSidecar = async (program, type, data) => {
         sidecar.stdout.on('data', e => stdout.push(e));
         let hadStderr = false;
         sidecar.stderr.on('data', e => {
+            if (!hadStderr)
+                reject(e);
             hadStderr = true;
-            reject(e);
         });
 
         // Report output on exit

--- a/src/utils/sidecar.js
+++ b/src/utils/sidecar.js
@@ -7,15 +7,16 @@ export const openSidecar = async (program, type, data) => {
         // Listen for output
         const stdout = [];
         sidecar.stdout.on('data', e => stdout.push(e));
-        const stderr = [];
-        sidecar.stderr.on('data', e => stderr.push(e));
+        let hadStderr = false;
+        sidecar.stderr.on('data', e => {
+            hadStderr = true;
+            reject(e);
+        });
 
         // Report output on exit
         sidecar.on('close', () => {
-            if (stderr.length > 0)
-                reject(stderr.join('\n'));
-            else
-                resolve(stdout.join('\n'));
+            if (!hadStderr)
+                resolve(stdout);
         });
     });
 

--- a/src/utils/sidecar.js
+++ b/src/utils/sidecar.js
@@ -1,5 +1,13 @@
 import {Command} from "@tauri-apps/api/shell";
 
+/**
+ * 
+ * @param {string} program Name of executable to run
+ * @param {string} type Command to run inside executable
+ * @param {any} data Optional data required for command
+ * @returns {Promise<string[]>} Lines from executable's stdout
+ * @throws {string} First line of executable's stderr
+ */
 export const openSidecar = async (program, type, data) => {
     const sidecar = Command.sidecar(program);
 
@@ -7,18 +15,10 @@ export const openSidecar = async (program, type, data) => {
         // Listen for output
         const stdout = [];
         sidecar.stdout.on('data', e => stdout.push(e));
-        let hadStderr = false;
-        sidecar.stderr.on('data', e => {
-            if (!hadStderr)
-                reject(e);
-            hadStderr = true;
-        });
+        sidecar.stderr.on('data', e => reject(e));
 
         // Report output on exit
-        sidecar.on('close', () => {
-            if (!hadStderr)
-                resolve(stdout);
-        });
+        sidecar.on('close', () => resolve(stdout));
     });
 
     const child = await sidecar.spawn();


### PR DESCRIPTION
The code has will fall back to the non-prefixed version if the new section is not found, for backwards compatibility. Writing however, will only ever write to the new version.

This is to be paired with LucidVR/opengloves-driver#130 to address LucidVR/opengloves-driver#129