### PR TITLE
Make 4095 default analog encoding

### DIFF
--- a/resources/settings/default.vrsettings
+++ b/resources/settings/default.vrsettings
@@ -61,12 +61,12 @@
   {
     "__type": "encoding_protocol: 0",
     "__title": "Legacy Encoding",
-    "max_analog_value": 1023
+    "max_analog_value": 4095
   },
   "encoding_alpha":
   {
     "__type": "encoding_protocol: 1",
     "__title": "Alpha Protocol",
-    "max_analog_value": 1023
+    "max_analog_value": 4095
   }
 }


### PR DESCRIPTION
Results for this are based on the poll in the discord server.
As of 34 minutes into the poll, 42 people voted for 4095 as analog max, 2 people voted for 1023 as default

This is to be merged in along with the next release of opengloves that includes 4095 as default.