### PR TITLE
Remove UI Settings tab from menubar

### DIFF
--- a/src/routes/(reactive)/+layout.svelte
+++ b/src/routes/(reactive)/+layout.svelte
@@ -21,10 +21,6 @@
 				{
 					title: 'Functions',
 					href: '/functions'
-				},
-				{
-					title: 'UI Settings',
-					href: '/settings'
 				}
 			]}
 			bind:index_active={$state.current_page}


### PR DESCRIPTION
The page is currently empty, so I figured I'd remove it.